### PR TITLE
Omit 'spinnaker' and 'halyard' namespaces from scanning

### DIFF
--- a/scripts/install/quick-install.yml
+++ b/scripts/install/quick-install.yml
@@ -236,8 +236,10 @@ data:
             serviceAccount: true
             namespaces: []
             omitNamespaces:
+            - halyard
             - kube-public
             - kube-system
+            - spinnaker
             kinds: []
             omitKinds: []
             customResources: []


### PR DESCRIPTION
These namespaces contain processes that shouldn't be managed from Spinnaker