### PR TITLE
Use a unique path for Cloud Build artifacts

### DIFF
--- a/samples/helloworldwebapp/templates/pipelines/deployprod_json.template
+++ b/samples/helloworldwebapp/templates/pipelines/deployprod_json.template
@@ -7,7 +7,7 @@
       "id": "d9013e3f-e9cd-4f18-ace6-ef14369b7fec",
       "matchArtifact": {
         "id": "b4557686-0d7e-4163-8cb5-f7e7f1310fa8",
-        "name": "gs://$BUCKET_NAME/helloworldwebapp-manifests/prod-replicaset.yaml",
+        "name": "gs://$BUCKET_NAME/helloworldwebapp-manifests/.*/prod-replicaset.yaml",
         "type": "gcs/object"
       },
       "useDefaultArtifact": false,
@@ -29,7 +29,7 @@
       "id": "730af75f-50ad-49ab-b754-ec8ae75938f8",
       "matchArtifact": {
         "id": "1d82dc39-76e1-4a96-8f9c-7f68b3edfa67",
-        "name": "gs://$BUCKET_NAME/helloworldwebapp-manifests/prod-namespace.yaml",
+        "name": "gs://$BUCKET_NAME/helloworldwebapp-manifests/.*/prod-namespace.yaml",
         "type": "gcs/object"
       },
       "useDefaultArtifact": false,
@@ -40,7 +40,7 @@
       "id": "76641671-4d6b-4aee-94b4-dba73fbabfcd",
       "matchArtifact": {
         "id": "63b7838b-045b-4681-9a54-852cdb22efd0",
-        "name": "gs://$BUCKET_NAME/helloworldwebapp-manifests/prod-service.yaml",
+        "name": "gs://$BUCKET_NAME/helloworldwebapp-manifests/.*/prod-service.yaml",
         "type": "gcs/object"
       },
       "useDefaultArtifact": false,

--- a/samples/helloworldwebapp/templates/pipelines/deploystaging_json.template
+++ b/samples/helloworldwebapp/templates/pipelines/deploystaging_json.template
@@ -7,7 +7,7 @@
       "id": "04429e2c-b48c-48e7-ac9b-6fdc4e3d7f59",
       "matchArtifact": {
         "id": "f52080c9-c9ce-4406-a869-e04af6c01389",
-        "name": "gs://$BUCKET_NAME/helloworldwebapp-manifests/staging-replicaset.yaml",
+        "name": "gs://$BUCKET_NAME/helloworldwebapp-manifests/.*/staging-replicaset.yaml",
         "type": "gcs/object"
       },
       "useDefaultArtifact": false,
@@ -29,7 +29,7 @@
       "id": "097c2e8e-295f-4020-85d9-18ed18f6133b",
       "matchArtifact": {
         "id": "4be2cb5b-bfee-43cc-a2e8-c544777f3436",
-        "name": "gs://$BUCKET_NAME/helloworldwebapp-manifests/staging-namespace.yaml",
+        "name": "gs://$BUCKET_NAME/helloworldwebapp-manifests/.*/staging-namespace.yaml",
         "type": "gcs/object"
       },
       "useDefaultArtifact": false,
@@ -40,7 +40,7 @@
       "id": "24f64da7-9eac-46df-8b0d-f7092b6a03e4",
       "matchArtifact": {
         "id": "09755b68-001a-4d61-bb17-985546618e5f",
-        "name": "gs://$BUCKET_NAME/helloworldwebapp-manifests/staging-service.yaml",
+        "name": "gs://$BUCKET_NAME/helloworldwebapp-manifests/.*/staging-service.yaml",
         "type": "gcs/object"
       },
       "useDefaultArtifact": false,

--- a/samples/helloworldwebapp/templates/repo/cloudbuild_yaml.template
+++ b/samples/helloworldwebapp/templates/repo/cloudbuild_yaml.template
@@ -24,5 +24,5 @@ images:
   - 'gcr.io/$PROJECT_ID/$REPO_NAME:$SHORT_SHA'
 artifacts:
   objects:
-    location: gs://$BUCKET_NAME/helloworldwebapp-manifests/
+    location: gs://$BUCKET_NAME/helloworldwebapp-manifests/$SHORT_SHA
     paths: [ 'config-all/*' ]


### PR DESCRIPTION
Otherwise, there is a small chance of a race condition: a Spinnaker pipeline triggered by Cloud Build job N could in theory retrieve YAML files pushed by Cloud Build job N+1 if e.g. there was a delay before it received the event.

Tested with a fork of spinnaker-for-gcp:

![image](https://user-images.githubusercontent.com/223702/62093367-05b9de00-b247-11e9-966b-5f2ae8be6cef.png)

![image](https://user-images.githubusercontent.com/223702/62093549-ae683d80-b247-11e9-9125-f1e211992f70.png)

![image](https://user-images.githubusercontent.com/223702/62093627-00a95e80-b248-11e9-8837-d904afcb4d23.png)

![image](https://user-images.githubusercontent.com/223702/62093636-174fb580-b248-11e9-9f33-34889b2a4e9b.png)

![image](https://user-images.githubusercontent.com/223702/62093701-4f56f880-b248-11e9-8ea6-6cd3d5c7063a.png)

![image](https://user-images.githubusercontent.com/223702/62093750-76adc580-b248-11e9-9036-e2c7e6d64860.png)

![image](https://user-images.githubusercontent.com/223702/62094010-8aa5f700-b249-11e9-93a6-16e9744844a7.png)

(failure of second pipeline expected on first run ^^)

![image](https://user-images.githubusercontent.com/223702/62097449-d27e4b80-b254-11e9-9170-7d6eb0e88633.png)


