### PR TITLE
Check that git identity is configured when pushing config

### DIFF
--- a/scripts/manage/push_config.sh
+++ b/scripts/manage/push_config.sh
@@ -13,7 +13,7 @@ if [ -z "$GIT_USERNAME" ]; then
 fi
 
 if [ -z "$GIT_EMAIL" ]; then
-  bold "Your Git account email is not set. Run 'git config --global user.email \"you@example.com\"' and try again"
+  bold "Your Git account email is not set. Run 'git config --global user.email \"you@example.com\"' and try again."
   exit 1
 fi
 

--- a/scripts/manage/push_config.sh
+++ b/scripts/manage/push_config.sh
@@ -8,7 +8,7 @@ GIT_USERNAME=$(git config --global --get user.name)
 GIT_EMAIL=$(git config --global --get user.email)
 
 if [ -z "$GIT_USERNAME" ]; then
-  bold "Your Git account username is not set. Run 'git config --global user.name \"Your Name\"' and try again"
+  bold "Your Git account username is not set. Run 'git config --global user.name \"Your Name\"' and try again."
   exit 1
 fi
 

--- a/scripts/manage/push_config.sh
+++ b/scripts/manage/push_config.sh
@@ -4,6 +4,19 @@ bold() {
   echo ". $(tput bold)" "$*" "$(tput sgr0)";
 }
 
+GIT_USERNAME=$(git config --global --get user.name)
+GIT_EMAIL=$(git config --global --get user.email)
+
+if [ -z "$GIT_USERNAME" ]; then
+  bold "Your Git account username is not set. Run 'git config --global user.name \"Your Name\"' and try again"
+  exit 1
+fi
+
+if [ -z "$GIT_EMAIL" ]; then
+  bold "Your Git account email is not set. Run 'git config --global user.email \"you@example.com\"' and try again"
+  exit 1
+fi
+
 source ~/spinnaker-for-gcp/scripts/install/properties
 
 # TODO(duftler): Add check to ensure that we are not overriding with older or empty config.


### PR DESCRIPTION
Omission of a configured git name or email will cause the commit to CSR to fail. I noticed this while testing in Cloudshell.