### PR TITLE
Correct the path used in rm for hal pod

### DIFF
--- a/scripts/manage/push_config.sh
+++ b/scripts/manage/push_config.sh
@@ -137,7 +137,7 @@ copy_if_exists $PARENT_DIR/.spin/key.json deployment_config_files "$PROJECT_ID\.
 
 # Remove old persistent config so new config can be copied into place.
 bold "Removing halyard/$HALYARD_POD:/home/spinnaker/.hal..."
-kubectl -n halyard exec $HALYARD_POD -- bash -c "rm -rf $PARENT_DIR/.hal/*"
+kubectl -n halyard exec $HALYARD_POD -- bash -c "rm -rf ~/.hal/*"
 
 # Copy new config into place.
 bold "Copying $PARENT_DIR/.hal into halyard/$HALYARD_POD:/home/spinnaker/.hal..."


### PR DESCRIPTION
Closes https://github.com/GoogleCloudPlatform/spinnaker-for-gcp/issues/155

I tested setup, editing the halyard config and service settings, pushing up changes, pulling down changes, and completing the CSR restore workflow. I also audited other references to `$PARENT_DIR` to check for these kind of issues.