### PR TITLE
Do not eval PROJECT_ID variable in DOMAIN_NAME during setup

### DIFF
--- a/scripts/install/setup_properties.sh
+++ b/scripts/install/setup_properties.sh
@@ -193,7 +193,7 @@ export SECRET_NAME=\$DEPLOYMENT_NAME-oauth-client-secret
 
 # If you own a domain name and want to use that instead of this automatically-assigned one,
 # specify it here (you must be able to configure the dns settings).
-export DOMAIN_NAME=\$DEPLOYMENT_NAME.endpoints.$PROJECT_ID.cloud.goog
+export DOMAIN_NAME=\$DEPLOYMENT_NAME.endpoints.\$PROJECT_ID.cloud.goog
 
 # This email address will be granted permissions as an IAP-Secured Web App User.
 export IAP_USER=$(gcloud auth list --format="value(account)" --filter="status=ACTIVE")


### PR DESCRIPTION
If during initial setup PROJECT_ID was set incorrectly by user,
the DOMAIN_NAME variable gets eval'ed to the initial value.
This causes issues to while setting up endpoints, manage certs
in the later steps.