### PR TITLE
Updated GKE_CLUSTER_VERSION to 1.15.12

### DIFF
--- a/scripts/install/setup_properties.sh
+++ b/scripts/install/setup_properties.sh
@@ -152,7 +152,7 @@ cat >> ~/cloudshell_open/spinnaker-for-gcp/scripts/install/properties <<EOL
 export GKE_CLUSTER=${GKE_CLUSTER:-\$DEPLOYMENT_NAME}
 
 # These are only considered if a new GKE cluster is being created.
-export GKE_CLUSTER_VERSION=1.14.10
+export GKE_CLUSTER_VERSION=1.15.12
 export GKE_MACHINE_TYPE=n1-highmem-4
 export GKE_DISK_TYPE=pd-standard
 export GKE_DISK_SIZE=100


### PR DESCRIPTION
According to https://cloud.google.com/kubernetes-engine/docs/release-notes#august_06_2020_r26, version 1.14 will not available and we have to use at least version 1.15.12