### PR TITLE
Add hal daemon minimal required limits to prevent deployment hangs

### DIFF
--- a/scripts/install/quick-install.yml
+++ b/scripts/install/quick-install.yml
@@ -90,6 +90,10 @@ spec:
             - -q
             - --spider
             - http://localhost:8064/health
+        resources:
+          requests:
+            cpu: 10m
+            memory: 256Mi
         ports:
         - containerPort: 8064
         volumeMounts:


### PR DESCRIPTION
In this PR I am adding minimal resources to hal daemon which can get stack when other components in default setup are resource hungry.
Addresses Issue https://github.com/GoogleCloudPlatform/spinnaker-for-gcp/issues/211