### PR TITLE
Add hal daemon resource requirements

### DIFF
--- a/scripts/install/quick-install.yml
+++ b/scripts/install/quick-install.yml
@@ -90,6 +90,10 @@ spec:
             - -q
             - --spider
             - http://localhost:8064/health
+        resources:
+          requests:
+            cpu: 10m
+            memory: 256Mi
         ports:
         - containerPort: 8064
         volumeMounts:


### PR DESCRIPTION
This PR resolves https://github.com/GoogleCloudPlatform/spinnaker-for-gcp/issues/211.
In a situation when the cluster is busy(other components are without limits and resource-hungry) redeployment is stuck and not responsive. This PR prevents this situation by adding minimal required resource requirement for hal daemon