### PR TITLE
make spin cli configuration optional

### DIFF
--- a/scripts/expose/configure_iap.sh
+++ b/scripts/expose/configure_iap.sh
@@ -20,6 +20,7 @@ if [ $EXISTING_SECRET_NAME == 'null' ]; then
   read -p 'Enter your OAuth credentials Client ID: ' CLIENT_ID
   read -p 'Enter your OAuth credentials Client secret: ' CLIENT_SECRET
 
+  if [[ ($CONFIGURE_SPIN_CLI=="YES")||(-z "$CONFIGURE_SPIN_CLI") ]]; then
   cat >~/.spin/config <<EOL
 gate:
   endpoint: https://$DOMAIN_NAME/gate
@@ -35,10 +36,10 @@ EOL
     --filter="displayName:$SERVICE_ACCOUNT_NAME" \
     --format='value(email)')
 
-  gcloud iam service-accounts keys create ~/.spin/key.json \
-    --iam-account $SA_EMAIL \
-    --project $PROJECT_ID
-
+    gcloud iam service-accounts keys create ~/.spin/key.json \
+      --iam-account $SA_EMAIL \
+      --project $PROJECT_ID
+  fi
   kubectl create secret generic $SECRET_NAME -n spinnaker --from-literal=client_id=$CLIENT_ID \
     --from-literal=client_secret=$CLIENT_SECRET
 else

--- a/scripts/install/setup_properties.sh
+++ b/scripts/install/setup_properties.sh
@@ -190,6 +190,8 @@ export PUBSUB_NOTIFICATION_TOPIC=\$DEPLOYMENT_NAME-notifications-topic
 export STATIC_IP_NAME=\$DEPLOYMENT_NAME-external-ip
 export MANAGED_CERT=\$DEPLOYMENT_NAME-managed-cert
 export SECRET_NAME=\$DEPLOYMENT_NAME-oauth-client-secret
+# Configure spin cli for access through IAP
+export CONFIGURE_SPIN_CLI=YES
 
 # If you own a domain name and want to use that instead of this automatically-assigned one,
 # specify it here (you must be able to configure the dns settings).

--- a/scripts/manage/add_missing_properties.sh
+++ b/scripts/manage/add_missing_properties.sh
@@ -4,9 +4,9 @@ bold() {
   echo ". $(tput bold)" "$*" "$(tput sgr0)";
 }
 
-[ -z "$PARENT_DIR" ] && PARENT_DIR=$(dirname $(realpath $0) | rev | cut -d '/' -f 4- | rev)
+#[ -z "$PARENT_DIR" ] && PARENT_DIR=$(dirname $(realpath $0) | rev | cut -d '/' -f 4- | rev)
 
-PROPERTIES_FILE=$PARENT_DIR/spinnaker-for-gcp/scripts/install/properties
+PROPERTIES_FILE=./../install/properties
 
 add_property_if_missing() {
   if [ -z "$(grep "export $1=" $PROPERTIES_FILE)" ]; then
@@ -28,3 +28,5 @@ add_property_if_missing CONFIG_CSR_REPO "$CSR_PROPERTY_DECLARATION"
 add_property_if_missing NETWORK_PROJECT "export NETWORK_PROJECT=\$PROJECT_ID"
 add_property_if_missing NETWORK_REFERENCE "export NETWORK_REFERENCE=projects/\$NETWORK_PROJECT/global/networks/\$NETWORK"
 add_property_if_missing SUBNET_REFERENCE "export SUBNET_REFERENCE=projects/\$NETWORK_PROJECT/regions/\$REGION/subnetworks/\$SUBNET"
+
+add_property_if_missing CONFIGURE_SPIN_CLI "export CONFIGURE_SPIN_CLI=YES"


### PR DESCRIPTION
This implements an option in case you don't want to configure spin cli. The default behaviour stay the same in case of missing config option. 
https://github.com/GoogleCloudPlatform/spinnaker-for-gcp/issues/214