### PR TITLE
update GKE version in setup_properties.sh

### DIFF
--- a/scripts/install/setup_properties.sh
+++ b/scripts/install/setup_properties.sh
@@ -152,7 +152,7 @@ cat >> ~/cloudshell_open/spinnaker-for-gcp/scripts/install/properties <<EOL
 export GKE_CLUSTER=${GKE_CLUSTER:-\$DEPLOYMENT_NAME}
 
 # These are only considered if a new GKE cluster is being created.
-export GKE_CLUSTER_VERSION=1.15.12
+export GKE_CLUSTER_VERSION=1.18.16
 export GKE_MACHINE_TYPE=n1-highmem-4
 export GKE_DISK_TYPE=pd-standard
 export GKE_DISK_SIZE=100


### PR DESCRIPTION
GKE version 1.15.12 is no longer an available option and as a result, the setup script fails to deploy the spinnaker-1 GKE cluster. Updating the GKE_CLUSTER_VERSION value in setup_properties.sh with a valid GKE version resolves the issue and allows the setup script to proceed.  

Additionally, individuals following the guide at https://cloud.google.com/architecture/continuous-delivery-spinnaker-kubernetes-engine and using the sample-app from https://gke-spinnaker.storage.googleapis.com/sample-app-v4.tgz will need to update each deployments' apiVersion to apps/v1 and add the spec.selector field.