### PR TITLE
Update: setup_properties.sh

### DIFF
--- a/scripts/install/setup_properties.sh
+++ b/scripts/install/setup_properties.sh
@@ -152,7 +152,7 @@ cat >> ~/cloudshell_open/spinnaker-for-gcp/scripts/install/properties <<EOL
 export GKE_CLUSTER=${GKE_CLUSTER:-\$DEPLOYMENT_NAME}
 
 # These are only considered if a new GKE cluster is being created.
-export GKE_CLUSTER_VERSION=1.18.16
+export GKE_CLUSTER_VERSION=1.18.17
 export GKE_MACHINE_TYPE=n1-highmem-4
 export GKE_DISK_TYPE=pd-standard
 export GKE_DISK_SIZE=100


### PR DESCRIPTION
- Updated GKE version to 1.18.17 in order to resolve error "No valid versions with the prefix "1.18.16" found."
- Related buganizer: http://b/190353985 