### PR TITLE
fix: setup scripts fail to create cluster v1.18.16

### DIFF
--- a/scripts/install/setup.sh
+++ b/scripts/install/setup.sh
@@ -213,8 +213,8 @@ if [ -z "$CLUSTER_EXISTS" ]; then
   # TODO: Move some of these config settings to properties file.
   # TODO: Should this be regional instead?
   eval gcloud beta container clusters create $GKE_CLUSTER --project $PROJECT_ID \
-    --zone $ZONE --username "admin" --network $NETWORK_REFERENCE --subnetwork $SUBNET_REFERENCE \
-    --cluster-version $GKE_CLUSTER_VERSION --machine-type $GKE_MACHINE_TYPE \
+    --zone $ZONE --network $NETWORK_REFERENCE --subnetwork $SUBNET_REFERENCE \
+    --release-channel $GKE_RELEASE_CHANNEL --machine-type $GKE_MACHINE_TYPE \
     --disk-type $GKE_DISK_TYPE --disk-size $GKE_DISK_SIZE --service-account $SA_EMAIL \
     --num-nodes $GKE_NUM_NODES --enable-stackdriver-kubernetes --enable-autoupgrade \
     --enable-autorepair --enable-ip-alias --addons HorizontalPodAutoscaling,HttpLoadBalancing \

--- a/scripts/install/setup_properties.sh
+++ b/scripts/install/setup_properties.sh
@@ -152,7 +152,7 @@ cat >> ~/cloudshell_open/spinnaker-for-gcp/scripts/install/properties <<EOL
 export GKE_CLUSTER=${GKE_CLUSTER:-\$DEPLOYMENT_NAME}
 
 # These are only considered if a new GKE cluster is being created.
-export GKE_CLUSTER_VERSION=1.18.16
+export GKE_RELEASE_CHANNEL=stable
 export GKE_MACHINE_TYPE=n1-highmem-4
 export GKE_DISK_TYPE=pd-standard
 export GKE_DISK_SIZE=100


### PR DESCRIPTION
Following the marketplace tutorial, the current GKE version `1.18.16` in `setup_properties.sh` fails with errors around the inability to enable basic auth.

### Basic auth removal

This PR removes `--username "admin"` (basic auth).

**Q:** Does disabling basic auth impact any extended operations beyond setup?

I skimmed the docs and didn't see basic auth references and `gcloud` captures GKE credentials.

### Version tweaks

Looking at the history of `setup.sh`, most of the commits are GKE_VERSION house keeping.

![image](https://user-images.githubusercontent.com/4601051/121486545-d9b92900-c996-11eb-9714-ae812821dce1.png)

The PR also swaps out a specific cluster version with a release channel variable `GKE_RELEASE_CHANNEL`. Also, `GKE_CLUSTER_VERSION` is no longer necessary.

![image](https://user-images.githubusercontent.com/4601051/121486573-e047a080-c996-11eb-875e-55d9da3c0335.png)

I understand there's value to pinning a specific version in production clusters. However, it's safe to assume the setup script will only run the first time. As folks adopt "day-2" operations, an upgrade plan will follow.