### PR TITLE
Centralize and fix random identifier generation.

### DIFF
--- a/scripts/install/setup_properties.sh
+++ b/scripts/install/setup_properties.sh
@@ -168,15 +168,15 @@ export SERVICE_ACCOUNT_NAME="${SERVICE_ACCOUNT_NAME:-"\$DEPLOYMENT_NAME-acc-$(da
 export REDIS_INSTANCE=\$DEPLOYMENT_NAME
 
 # If bucket does not exist, it will be created.
-export BUCKET_NAME="\$DEPLOYMENT_NAME-$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 20 | head -n 1)-$(date +"%s")"
+export BUCKET_NAME="\$DEPLOYMENT_NAME-$(random_identifier 20)-$(date +"%s")"
 export BUCKET_URI="gs://\$BUCKET_NAME"
 
 # If CSR repo does not exist, it will be created.
 export CONFIG_CSR_REPO=\$DEPLOYMENT_NAME-config
 
 # Used to authenticate calls to the audit log Cloud Function.
-export AUDIT_LOG_UNAME="$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 20 | head -n 1)-$(date +"%s")"
-export AUDIT_LOG_PW="$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 20 | head -n 1)-$(date +"%s")"
+export AUDIT_LOG_UNAME="$(random_identifier 20)-$(date +"%s")"
+export AUDIT_LOG_PW="$(random_identifier 20)-$(date +"%s")"
 
 export CLOUD_FUNCTION_NAME="\${DEPLOYMENT_NAME//-}AuditLog"
 

--- a/scripts/manage/add_gke_account.sh
+++ b/scripts/manage/add_gke_account.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+readonly THIS_DIRECTORY=$(cd $(dirname "${0}") && pwd)
+
+source "${THIS_DIRECTORY}/service_utils.sh"
+
 bold() {
   echo ". $(tput bold)" "$*" "$(tput sgr0)";
 }
@@ -64,7 +68,7 @@ for r in "${GKE_REQUIRED_ROLES[@]}"; do
 done
 
 mkdir -p ~/.hal/default/credentials
-KUBECONFIG_FILENAME="kubeconfig-$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 9 | head -n 1)"
+KUBECONFIG_FILENAME="kubeconfig-$(random_identifier 9)"
 
 bold "Copying ~/.kube/config into ~/.hal/default/credentials/$KUBECONFIG_FILENAME so it can be pushed to your halyard daemon's pod..."
 

--- a/scripts/manage/service_utils.sh
+++ b/scripts/manage/service_utils.sh
@@ -50,3 +50,17 @@ check_for_shared_vpc() {
     exit 1
   fi
 }
+
+# Generate random alpha-numeric characters in the set [0-9a-z].
+#
+# $1: Number of characters to generate.
+random_identifier() {
+  local size=$((${1}))
+  if [[ $((size)) -le 0 ]]; then
+    echo "Invalid identifier size (${size})." >&2
+    return 1
+  fi
+  cat /dev/urandom 2>/dev/null | \
+    tr -dc 'a-z0-9' 2>/dev/null | \
+    head -c $((size))
+}


### PR DESCRIPTION
In some subshells
`cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 20 | head -n 1`
can hang with the pipe being closed by `head` leaving `fold`
attempting to write into a pipe which blocks indefinitely.
This removes the buffering fold performs by changing the pipeline
to read a byte at a time and stop when the number of required
random characters is satisfied.

Fixes #245