### PR TITLE
Select the Spinnaker K8s context before operating on the cluster.

### DIFF
--- a/scripts/manage/apply_config.sh
+++ b/scripts/manage/apply_config.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+source ~/cloudshell_open/spinnaker-for-gcp/scripts/manage/service_utils.sh
+select_spinnaker_kubernetes_context || exit $?
+
 HALYARD_POD=spin-halyard-0
 
 # TODO(duftler): Use --wait-for-completion?

--- a/scripts/manage/connect_to_redis.sh
+++ b/scripts/manage/connect_to_redis.sh
@@ -17,6 +17,9 @@ export REDIS_INSTANCE_HOST=$(gcloud redis instances list \
 
 bold "Locating redis-cli deployment..."
 
+source ~/cloudshell_open/spinnaker-for-gcp/scripts/manage/service_utils.sh
+select_spinnaker_kubernetes_context || exit $?
+
 REDIS_CLI_DEPLOYMENT=$(kubectl get deployments -n spinnaker --field-selector metadata.name=redisbox \
   --output name)
 

--- a/scripts/manage/connect_unsecured.sh
+++ b/scripts/manage/connect_unsecured.sh
@@ -8,6 +8,9 @@ source ~/cloudshell_open/spinnaker-for-gcp/scripts/install/properties
 
 ~/cloudshell_open/spinnaker-for-gcp/scripts/manage/check_project_mismatch.sh
 
+source ~/cloudshell_open/spinnaker-for-gcp/scripts/manage/service_utils.sh
+select_spinnaker_kubernetes_context || exit $?
+
 bold "Locating Deck pod..."
 
 DECK_POD=$(kubectl -n spinnaker get pods -l cluster=spin-deck,app=spin \

--- a/scripts/manage/deploy_application_manifest.sh
+++ b/scripts/manage/deploy_application_manifest.sh
@@ -24,6 +24,8 @@ else
   APP_MANIFEST_MIDDLE=spinnaker_application_manifest_middle_secured.yaml
 fi
 
+select_spinnaker_kubernetes_context || exit $?
+
 kubectl apply -f "https://raw.githubusercontent.com/GoogleCloudPlatform/marketplace-k8s-app-tools/master/crd/app-crd.yaml"
 cat $PARENT_DIR/spinnaker-for-gcp/templates/spinnaker_application_manifest_top.yaml \
   $PARENT_DIR/spinnaker-for-gcp/templates/$APP_MANIFEST_MIDDLE \

--- a/scripts/manage/pull_config.sh
+++ b/scripts/manage/pull_config.sh
@@ -14,12 +14,7 @@ source $PARENT_DIR/spinnaker-for-gcp/scripts/manage/service_utils.sh
 
 $PARENT_DIR/spinnaker-for-gcp/scripts/manage/check_duplicate_dirs.sh || exit 1
 
-CURRENT_CONTEXT=$(kubectl config current-context)
-
-if [ "$?" != "0" ]; then
-  bold "No current Kubernetes context is configured."
-  exit 1
-fi
+select_spinnaker_kubernetes_context || exit $?
 
 HALYARD_POD=spin-halyard-0
 

--- a/scripts/manage/push_config.sh
+++ b/scripts/manage/push_config.sh
@@ -15,38 +15,9 @@ source $PARENT_DIR/spinnaker-for-gcp/scripts/manage/service_utils.sh
 $PARENT_DIR/spinnaker-for-gcp/scripts/manage/check_duplicate_dirs.sh || exit 1
 $PARENT_DIR/spinnaker-for-gcp/scripts/manage/check_git_config.sh || exit 1
 
-source "$PROPERTIES_FILE"
-
 # TODO(duftler): Add check to ensure that we are not overriding with older or empty config.
 
-CURRENT_CONTEXT=$(kubectl config current-context)
-
-if [ "$?" != "0" ]; then
-  bold "No current Kubernetes context is configured."
-  exit 1
-fi
-
-CURRENT_CONTEXT_PROJECT=$(echo $CURRENT_CONTEXT | cut -d '_' -f 2)
-CURRENT_CONTEXT_ZONE=$(echo $CURRENT_CONTEXT | cut -d '_' -f 3)
-CURRENT_CONTEXT_CLUSTER=$(echo $CURRENT_CONTEXT | cut -d '_' -f 4)
-
-if [ $CURRENT_CONTEXT_PROJECT != $PROJECT_ID ]; then
-  bold "Your Spinnaker config references project $PROJECT_ID, but you are connected to a cluster in project $CURRENT_CONTEXT_PROJECT."
-  bold "Use 'kubectl config use-context' to connect to the correct cluster before pushing the config."
-  exit 1
-fi
-
-if [ $CURRENT_CONTEXT_ZONE != $ZONE ]; then
-  bold "Your Spinnaker config references zone $ZONE, but you are connected to a cluster in zone $CURRENT_CONTEXT_ZONE."
-  bold "Use 'kubectl config use-context' to connect to the correct cluster before pushing the config."
-  exit 1
-fi
-
-if [ $CURRENT_CONTEXT_CLUSTER != $GKE_CLUSTER ]; then
-  bold "Your Spinnaker config references cluster $GKE_CLUSTER, but you are connected to cluster $CURRENT_CONTEXT_CLUSTER."
-  bold "Use 'kubectl config use-context' to connect to the correct cluster before pushing the config."
-  exit 1
-fi
+select_spinnaker_kubernetes_context || exit $?
 
 source $PARENT_DIR/spinnaker-for-gcp/scripts/manage/cluster_utils.sh
 

--- a/scripts/manage/service_utils.sh
+++ b/scripts/manage/service_utils.sh
@@ -50,3 +50,47 @@ check_for_shared_vpc() {
     exit 1
   fi
 }
+
+# Get the name of the kubectl context from a cluster name.
+#
+# $1: Cluster name.
+get_kubernetes_context_name() {
+  # sed statement removes the current selection column.
+  kubectl config get-contexts --no-headers | \
+    sed 's/^[^ ]* *//' | \
+    awk '$2 ~ /'"${1}"'/ { print $1 }'
+}
+
+# Use kubectl config use-context to select the context that points at the
+# Spinnaker cluster referenced by install/properties.
+select_spinnaker_kubernetes_context() {
+  if [[ "${PROJECT_ID}" != "" &&
+        "${ZONE}" != "" &&
+        "${DEPLOYMENT_NAME}" != "" ]]; then
+    local spinnaker_cluster="gke_${PROJECT_ID}_${ZONE}_${DEPLOYMENT_NAME}"
+    local spinnaker_context=$(get_kubernetes_context_name "$spinnaker_cluster")
+    # If the expected Spinnaker context is missing, try fetching it.
+    if [[ "$spinnaker_context" == "" ]]; then
+      gcloud container clusters get-credentials \
+          --zone "$ZONE" "${DEPLOYMENT_NAME}" || return $?
+      spinnaker_context=$(get_kubernetes_context_name "${spinnaker_cluster}")
+      if [[ "$spinnaker_context" == "" ]]; then
+        bold "Failed to get GKE cluster credentials for ${spinnaker_cluster}"
+        return 1
+      fi
+    fi
+    kubectl config use-context "${spinnaker_context}" >/dev/null
+  else
+    # If install/properties wasn't loaded assume the current context is the
+    # Spinnaker cluster.
+    local current_context=$(kubectl config current-context)
+    if [[ "${current_context}" == "" ]]; then
+      bold "No current Kuberentes context is configured."
+      return 1
+    fi
+    bold "WARNING: scripts/install/properties not found, using Kubernetes" \
+         "context ${current_context}"
+  fi
+}
+
+select_spinnaker_kubernetes_context || exit $?

--- a/scripts/manage/update_halyard_daemon.sh
+++ b/scripts/manage/update_halyard_daemon.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
-bold() {
-  echo ". $(tput bold)" "$*" "$(tput sgr0)";
-}
-
+source ~/cloudshell_open/spinnaker-for-gcp/scripts/manage/service_utils.sh
 source ~/cloudshell_open/spinnaker-for-gcp/scripts/install/properties
 
 bold "Updating halyard daemon..."
@@ -13,4 +10,5 @@ if [ -z "$HALYARD_VERSION" ]; then
 	exit 1
 fi
 
+select_spinnaker_kubernetes_context || exit $?
 kubectl set image statefulset spin-halyard -n halyard halyard-daemon=us-docker.pkg.dev/spinnaker-community/docker/halyard:$HALYARD_VERSION


### PR DESCRIPTION
Since the cluster information is stored in
`scripts/install/properties`, this commit selects the Spinnaker
cluster using `kubectl config use-context` before trying to
read / write the cluster.

Fixes #251