### PR TITLE
refactor(scripts/expose/deck-ingress.yml): upgrade to networking.k8s.…

### DIFF
--- a/scripts/expose/deck-ingress.yml
+++ b/scripts/expose/deck-ingress.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: deck-ingress
@@ -7,6 +7,14 @@ metadata:
     ingress.gcp.kubernetes.io/pre-shared-cert: $MANAGED_CERT
     kubernetes.io/ingress.global-static-ip-name: $STATIC_IP_NAME
 spec:
-  backend:
-    serviceName: spin-deck
-    servicePort: 9000
+  rules:
+  - http:
+      paths:
+      - path: /*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: spin-deck
+            port:
+              number: 9000
+


### PR DESCRIPTION
…io/v1

As of K8s version v1.22 the "extensions/v1beta1" and "networking.k8s.io/v1beta1" API versions are no
longer supported. Given that the current stable version of GKE is 1.21, we should migrate to the
non-beta API version "networking.k8s.io/v1."
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122
https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions

This PR prevents people on K8s version v1.22 from experiencing an issue where the GKE ingress is not created because "extensions/v1beta1" is no longer supported. In my experience the "scripts/expose/configure_iap.sh" script will fail silently on K8s version v1.22 unless we fix this issue. 